### PR TITLE
Documentation for new CR process

### DIFF
--- a/review/developer/submitting-prs.md
+++ b/review/developer/submitting-prs.md
@@ -2,19 +2,34 @@
 
 Before submitting a PR, please check that your PR follows the guides below:
 -   [Writing Good PR Descriptions](pr-descriptions.md)
--   [Before Submmiting PRs](before-submitting-prs.md)
+-   [Before Submitting PRs](before-submitting-prs.md)
 
-Submitting a PR is simple.
--    You will mark a PR ready for review. [How to change the stage of a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request)
--    A PR will auto-assign a reviewer
--    You can ask subject matter expert to review the PR by adding them to reviewers. [How to request a pull request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review)
+## Submission Process
 
-All conversation around the PR should be kept in the Github PR, this way we can keep conversation and data around the PR in one place. (feel free to ping people in the PR comments).
+Submitting a PR is simple. 
+- You will mark a PR ready for review. [How to change the stage of a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request)
+- A team member will automatically be assigned to review your PR.
+- You will also ask subject matter expert to review the PR by adding them to reviewers. [How to request a pull request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review)
 
-If no one has claimed your code review in a reasonable amount of time, post the PR in a slack project channel and ping your team to review.
+All conversation around the PR should be kept in the Github PR, this way we can keep conversation and data around the PR
+in one place. (feel free to ping people in the PR comments).
+
+**All PRs require the approval of both the assigned reviewer, *and* the selected subject matter expert to be merged.**
+There are exceptions for [emergencies](../emergencies.md).
+
+Once reviewers leave feedback on your PR and you address their concerns you should request their review again using
+GitHub. This ensures they receive a notification of your updates.
+
+## Timeliness
+
+You should expect that your PR is reviewed by [the morning after](../reviewer/speed.md) it is submitted. If your PR
+isn't being reviewed in a timely manner you can remind the reviewer or ask the team for help getting your PR reviewed
+and merged.
 
 If you are requested to perform a code review
 - It is your responsibility to complete the code review in a timely manner, or
-- If you are not able to perform the code review, communicate to the PR's author and it is your responsiblity (reviewer's responsiblity) to find someone to take it in a timely manner.
+- If you are not able to perform the code review, communicate to the PR's author and find someone to agree to do the
+  review in your place to ensure it gets done in a timely manner.
+
 
 More detail please refer to [The Code Reviewer's Guide](../reviewer/index.md)

--- a/review/emergencies.md
+++ b/review/emergencies.md
@@ -1,9 +1,8 @@
 # Emergencies
 
 Sometimes there are emergency PRs that must pass through the entire code review
-process as quickly as
-possible.
-
+process as quickly as possible. In an emergency, you can merge a PR with just
+one reviewer, ideally a subject matter expert.
 
 
 ## What Is An Emergency? {#what}

--- a/review/reviewer/notifications.md
+++ b/review/reviewer/notifications.md
@@ -1,0 +1,30 @@
+# GitHub Assignment Notifications
+
+GitHub can notify you in Slack when you have been assigned a PR to review.
+It can also give you a scheduled summary of PRs that still need your attention.
+
+## Setup Slack with Github
+The GitHub app for Slack is preinstalled in the workspace.
+1. Visit https://github.com/settings/reminders and click the pencil next to your
+organization.
+2. From the slack workspace dropdown select `+ Add Slack workspace` or the `Authorize Slack workspace` button.
+3. You'll be redirected to Slack to authorize access. Click `Allow`
+4. After getting redirected back to GitHub, visit the organization page again.
+5. From here you can select the Slack organization to receive notifications in and configure notifications.
+
+## Configuring Notifications and Summaries
+The top section of the scheduled reminders form lets you set the days of the week, and time to receive summaries.
+
+You should check "Review requests assigned to you" to receive only notifications for pull requests directly assigned to
+you. It's not recommended to select "Review requests assigned to your team".
+
+## Setting Yourself Busy
+GitHub lets you set yourself busy to stop receiving notifications, and stop
+automatic code review assignments for you.
+
+To set yourself busy:
+1. Click on your avatar in GitHub
+2. In the sidebar click on "Set status"
+3. In the modal that comes up check "Busy"
+4. Optionally select when the status will be cleared
+5. Click "Set status"


### PR DESCRIPTION
* Adds details on the new CR process requiring two reviewers
* Details a 1 approval CR process for emergencies
* Details timeliness and what to do when you're not getting a review
* Adds documentation on Slack notifications, and setting yourself busy so you don't receive review requests